### PR TITLE
docs: add GitHub issue drafts generated from doc/issues.md

### DIFF
--- a/doc/github_issues_to_create.md
+++ b/doc/github_issues_to_create.md
@@ -1,0 +1,244 @@
+# GitHub Issues to Create
+
+Source: `doc/issues.md`
+
+This file mirrors each bullet in `doc/issues.md` as a proposed GitHub issue title/body draft.
+
+
+## 1. [General] Colors are slightly different from psx (map differently?)
+**Suggested labels:** `bug,general`
+
+**Body draft:**
+- Source section: General
+- Reported issue: colors are slightly different from psx (map differently?)
+
+## 2. [General] A few sfx are very loud and distorted (ex. warp sound, also when entering a bonus round)
+**Suggested labels:** `bug,general`
+
+**Body draft:**
+- Source section: General
+- Reported issue: a few sfx are very loud and distorted (ex. warp sound, also when entering a bonus round)
+
+## 3. [General] In some instances, game transitions occur too early (ex. game immediately jumps to win level screen when player lands on a warp platform, without playing either of crash's 'win level' animation sequences; some death sequences are cut short)
+**Suggested labels:** `bug,general`
+
+**Body draft:**
+- Source section: General
+- Reported issue: in some instances, game transitions occur too early (ex. game immediately jumps to win level screen when player lands on a warp platform, without playing either of crash's 'win level' animation sequences; some death sequences are cut short)
+
+## 4. [General] Main death sequence camera behavior is incorrect
+**Suggested labels:** `bug,general`
+
+**Body draft:**
+- Source section: General
+- Reported issue: main death sequence camera behavior is incorrect
+
+## 5. [General] Title sequence background images become too bright in some instances
+**Suggested labels:** `bug,general`
+
+**Body draft:**
+- Source section: General
+- Reported issue: title sequence background images become too bright in some instances
+
+## 6. [General] It is sometimes (but rarely) possible to jump in mid-air when beside walls
+**Suggested labels:** `bug,general`
+
+**Body draft:**
+- Source section: General
+- Reported issue: it is sometimes (but rarely) possible to jump in mid-air when beside walls
+
+## 7. [General] Demo mode does not function correctly
+**Suggested labels:** `bug,general`
+
+**Body draft:**
+- Source section: General
+- Reported issue: demo mode does not function correctly
+
+## 8. [General] Attempting to enter any title state other than the map from the main menu ultimately results in the game entering an infinite loop and/or crashing
+**Suggested labels:** `bug,general`
+
+**Body draft:**
+- Source section: General
+- Reported issue: attempting to enter any title state other than the map from the main menu ultimately results in the game entering an infinite loop and/or crashing
+
+## 9. [General] Compiling with optimization flags causes the game to behave differently (aside from performance improvements)
+**Suggested labels:** `bug,general`
+
+**Body draft:**
+- Source section: General
+- Reported issue: compiling with optimization flags causes the game to behave differently (aside from performance improvements)
+
+## 10. [General] Tree change tracking implementation is broken
+**Suggested labels:** `bug,general`
+
+**Body draft:**
+- Source section: General
+- Reported issue: tree change tracking implementation is broken
+
+## 11. [Map] Camera is incorrect
+**Suggested labels:** `bug,level:map`
+
+**Body draft:**
+- Source section: Per-level > Map
+- Reported issue: camera is incorrect
+
+## 12. [Map] Textures fail to load in some instances
+**Suggested labels:** `bug,level:map`
+
+**Body draft:**
+- Source section: Per-level > Map
+- Reported issue: textures fail to load in some instances
+
+## 13. [Rolling Stones] Falling pegs seem to be positioned slightly higher than Crash when Crash stands on them
+**Suggested labels:** `bug,level:rolling-stones`
+
+**Body draft:**
+- Source section: Per-level > Rolling Stones
+- Reported issue: falling pegs seem to be positioned slightly higher than Crash when Crash stands on them
+
+## 14. [Hog Wild] Player dies after respawning at a checkpoint
+**Suggested labels:** `bug,level:hog-wild`
+
+**Body draft:**
+- Source section: Per-level > Hog Wild
+- Reported issue: player dies after respawning at a checkpoint
+
+## 15. [Hog Wild] Crash skips the 'look back at camera and then jump on hog' animation sequence that typically begins hog levels
+**Suggested labels:** `bug,level:hog-wild`
+
+**Body draft:**
+- Source section: Per-level > Hog Wild
+- Reported issue: crash skips the 'look back at camera and then jump on hog' animation sequence that typically begins hog levels
+
+## 16. [Ripper Roo] Ripper Roo only makes a single jump before they disappear and restart their path
+**Suggested labels:** `bug,level:ripper-roo`
+
+**Body draft:**
+- Source section: Per-level > Ripper Roo
+- Reported issue: Ripper Roo only makes a single jump before they disappear and restart their path
+
+## 17. [The Lost City] Game crashes when attempting to kill lizards
+**Suggested labels:** `bug,level:the-lost-city`
+
+**Body draft:**
+- Source section: Per-level > The Lost City
+- Reported issue: game crashes when attempting to kill lizards
+
+## 18. [Temple Ruins] Approaching bats causes game to crash
+**Suggested labels:** `bug,level:temple-ruins`
+
+**Body draft:**
+- Source section: Per-level > Temple Ruins
+- Reported issue: approaching bats causes game to crash
+
+## 19. [Road To Nowhere] Objects do not detect solid floor; any wumpa fruit/lives released from boxes seem to fall past the floor without being stopped
+**Suggested labels:** `bug,level:road-to-nowhere`
+
+**Body draft:**
+- Source section: Per-level > Road To Nowhere
+- Reported issue: objects do not detect solid floor; any wumpa fruit/lives released from boxes seem to fall past the floor without being stopped
+
+## 20. [Sunset Vista] Same crashes as The Lost City, when attempting to kill lizards (note: RWaOC; corrupted animation eid?)
+**Suggested labels:** `bug,level:sunset-vista`
+
+**Body draft:**
+- Source section: Per-level > Sunset Vista
+- Reported issue: same crashes as The Lost City, when attempting to kill lizards (note: RWaOC; corrupted animation eid?)
+
+## 21. [Koala Kong] TNT boxes fall through the floor
+**Suggested labels:** `bug,level:koala-kong`
+
+**Body draft:**
+- Source section: Per-level > Koala Kong
+- Reported issue: TNT boxes fall through the floor
+
+## 22. [Koala Kong] Boulders launched by Koala Kong do not appear or are not thrown in the destined direction
+**Suggested labels:** `bug,level:koala-kong`
+
+**Body draft:**
+- Source section: Per-level > Koala Kong
+- Reported issue: boulders launched by Koala Kong do not appear or are not thrown in the destined direction
+
+## 23. [Cortex Power] Going near a MafiC causes the game to crash
+**Suggested labels:** `bug,level:cortex-power`
+
+**Body draft:**
+- Source section: Per-level > Cortex Power
+- Reported issue: going near a MafiC causes the game to crash
+
+## 24. [Toxic Waste] Solid ceiling is not detected
+**Suggested labels:** `bug,level:toxic-waste`
+
+**Body draft:**
+- Source section: Per-level > Toxic Waste
+- Reported issue: solid ceiling is not detected
+
+## 25. [Toxic Waste] Game crashes when dying in certain zones
+**Suggested labels:** `bug,level:toxic-waste`
+
+**Body draft:**
+- Source section: Per-level > Toxic Waste
+- Reported issue: game crashes when dying in certain zones
+
+## 26. [Pinstripe] Gun bullets do not do any damage to Crash
+**Suggested labels:** `bug,level:pinstripe`
+
+**Body draft:**
+- Source section: Per-level > Pinstripe
+- Reported issue: gun bullets do not do any damage to Crash
+
+## 27. [Lights Out] Lights go out too abruptly when time is up
+**Suggested labels:** `bug,level:lights-out`
+
+**Body draft:**
+- Source section: Per-level > Lights Out
+- Reported issue: lights go out too abruptly when time is up
+
+## 28. [Jaws of Darkness] Spider or shadow rotation angle is incorrect
+**Suggested labels:** `bug,level:jaws-of-darkness`
+
+**Body draft:**
+- Source section: Per-level > Jaws of Darkness
+- Reported issue: spider or shadow rotation angle is incorrect
+
+## 29. [Jaws of Darkness] Rotating pegs rotate way too fast
+**Suggested labels:** `bug,level:jaws-of-darkness`
+
+**Body draft:**
+- Source section: Per-level > Jaws of Darkness
+- Reported issue: rotating pegs rotate way too fast
+
+## 30. [N. Brio] N. Brio never transitions from his initial state
+**Suggested labels:** `bug,level:n-brio`
+
+**Body draft:**
+- Source section: Per-level > N. Brio
+- Reported issue: N. Brio never transitions from his initial state
+
+## 31. [The Lab] Game crashes when dying in certain zones
+**Suggested labels:** `bug,level:the-lab`
+
+**Body draft:**
+- Source section: Per-level > The Lab
+- Reported issue: game crashes when dying in certain zones
+
+## 32. [N. Cortex] Some particles shot by Cortex are not visible?
+**Suggested labels:** `bug,level:n-cortex`
+
+**Body draft:**
+- Source section: Per-level > N. Cortex
+- Reported issue: some particles shot by Cortex are not visible?
+
+## 33. [N. Cortex] Only some of the particles shot by Cortex damage Crash
+**Suggested labels:** `bug,level:n-cortex`
+
+**Body draft:**
+- Source section: Per-level > N. Cortex
+- Reported issue: only some of the particles shot by Cortex damage Crash
+
+## 34. [Stormy Ascent] Potion vials thrown by lab asses are not visible
+**Suggested labels:** `bug,level:stormy-ascent`
+
+**Body draft:**
+- Source section: Per-level > Stormy Ascent
+- Reported issue: potion vials thrown by lab asses are not visible


### PR DESCRIPTION
### Motivation
- Provide a copy-ready queue of GitHub issues derived from the tracked items in `doc/issues.md` so each reported problem can be posted to the issue tracker easily.
- Automatic creation from this environment was not possible, so a staged, human-reviewable file was produced instead.

### Description
- Added `doc/github_issues_to_create.md` containing one issue draft per bullet in `doc/issues.md`, for a total of 34 drafts. 
- Each draft includes a suggested title, suggested labels, and a short body that references the source section or level. 
- The drafts were generated programmatically by parsing `doc/issues.md` and writing a structured, copy-ready Markdown file.

### Testing
- Ran the parser script which successfully wrote `doc/github_issues_to_create.md` and reported `wrote 34 issues`.
- Checked for the GitHub CLI with `gh --version` and it was not available in the environment, so automatic issue posting was not attempted. 
- Confirmed the generated file was written and its contents inspected to ensure each bullet from `doc/issues.md` was represented as a draft.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b19f5c3f60832cba8797ccb4e0399f)